### PR TITLE
8.9.12 release

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -40,7 +40,7 @@ SITE_AUDIT_VERSION=7.x-3.x
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=dev-release/8.x-1.14
+GOVCMS_PROJECT_VERSION=1.14.0
 DRUPAL_CORE_VERSION=8.9.13
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)

--- a/.env.default
+++ b/.env.default
@@ -40,8 +40,8 @@ SITE_AUDIT_VERSION=7.x-3.x
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=1.13.0
-DRUPAL_CORE_VERSION=8.9.11
+GOVCMS_PROJECT_VERSION=dev-release/8.x-1.14
+DRUPAL_CORE_VERSION=8.9.13
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases


### PR DESCRIPTION
### Changes since 8.9.11:
- Create lean consolidated scaffold (D8/D9 SaaS, SaaS+, PaaS)
- The PHP version updated from 7.4.10 to 7.4.14
- Robots.txt for non-prod (nginx domains)
- Consolidate govcms lagoon images
- Move to new "uselagoon" namespace
- cURL error (60) SSL certificate problem
- Drupal core update from 8.9.11 to 8.9.13
- GovCMS8 distribution 8.x-1.14