### PR TITLE
fix: phpunit testing

### DIFF
--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -30,8 +30,11 @@ COPY .docker/images/govcms/mariadb-client.cnf /etc/my.cnf.d
 # Copy application files from the 'cli' stage to the current stage
 COPY --from=cli /app /app
 
+# Install dev dependencies (e.g. PHPUnit) excluded from the CLI image.
+RUN composer install --dev
+
 # Copy PHPUnit configuration and test files
-COPY --from=govcmstesting/tests:3.2.3-php8.3 /tests /app/tests
+COPY tests /app/tests
 
 # Set an environment variable for the webroot path
 ENV WEBROOT=web

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,23 @@
     },
     "require-dev": {
         "drupal/core-dev": "^11.0",
-        "palantirnet/drupal-rector": "^0.20.3"
+        "palantirnet/drupal-rector": "^0.20.3",
+        "weitzman/drupal-test-traits": "^2.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "drevops/behat-format-progress-fail": "^1.0",
+        "drevops/behat-screenshot": "^1.2",
+        "drevops/behat-steps": "^2.1",
+        "drupal/coder": "^8.3",
+        "drupal/drupal-extension": "^5.0",
+        "mglaman/drupal-check": "^1.4",
+        "palantirnet/drupal-rector": "^0.20",
+        "php-parallel-lint/php-console-highlighter": "^1.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "phploc/phploc": "*",
+        "phpmd/phpmd": "*",
+        "phpunit/phpunit": "*",
+        "symfony/dependency-injection": "^7",
+        "symfony/event-dispatcher": "^7"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
# Description

Internal ticket: [GOVCMS-14463](https://osbfinance.atlassian.net/browse/GOVCMS-14463)

Fixes phpunit testing by making all the testing dependencies `--dev` dependencies that only get included in the test image (not the `cli` image).

This also avoids having to `composer install` these deps at the scaffold layer, since they are baked into the test image.

It also adds support for Drupal Test Traits, as requested by https://github.com/govCMS/GovCMS/issues/1481

The exact dep version probably need a review, but this is a good starting point.

After this change is merged, we will need to merge https://github.com/govCMS/scaffold/pull/142 so that new projects can run tests out of the box.